### PR TITLE
feat: provide single LCDC instance creation

### DIFF
--- a/src/primitives/Account/Account.ts
+++ b/src/primitives/Account/Account.ts
@@ -3,18 +3,17 @@ import * as elliptic from "elliptic";
 import {MsgSend, Coin} from "../../Client/providers/LCDClient/core";
 import {RawKey} from "../../Client/providers/LCDClient/key";
 import {LCDClient} from "../../Client/providers/LCDClient/lcd/LCDClient";
+import * as console from "console";
 
 export class Account {
     private derivableAccountKey: DerivableKey;
     private accountIndex: number;
     private test: any;
     private test2: any;
-    private lcdcUrl: string;
-    private lcdc: LCDClient|null;
-    constructor(key: DerivableKey, accountIndex: number=0, lcdcUrl?: string|null) {
+    private lcdcInstance: LCDClient|null;
+    constructor(key: DerivableKey, accountIndex: number=0, lcdcInstance?: LCDClient|null) {
 
-        this.lcdc = null;
-        this.lcdcUrl = lcdcUrl ?? 'http://51.38.52.37:1317'
+        this.lcdcInstance = lcdcInstance ?? null;
         // this.privateKey = key.derivePath(`m/0/${index}`);
         // this.derivableAccountKey = key;
         this.derivableAccountKey = key.derivePath(`m/${accountIndex}'`);
@@ -53,26 +52,15 @@ export class Account {
 
        return isValid;
     }
-    async getLcdcClient(lcdcUrl?: string){
-        const URL = lcdcUrl ?? this.lcdcUrl;
-        console.log({URL});
-        if(!this.lcdc){
-            const lcdc = new LCDClient({
-                chainID: 'jmes-888',
-                // chainID: 'testing',
-                URL,
-                isClassic: true
-            });
-            this.lcdc = lcdc;
-        }
-
-        return this.lcdc;
+    async getLCDClient(){
+        return this.lcdcInstance;
     }
 
     async getBalance(address?: string){
-        const lcdcClient = await this.getLcdcClient();
+        const lcdClient = await this.getLCDClient();
+        if (!lcdClient) throw new Error('LCDClient not initialized');
         try {
-            const [balance] = await lcdcClient.bank.balance(address ?? this.getAddress());
+            const [balance] = await lcdClient.bank.balance(address ?? this.getAddress());
             return balance.get('ujmes') || new Coin("ujmes", 0)
         } catch (e){
             console.log(e);
@@ -80,31 +68,24 @@ export class Account {
         }
     }
     // @ts-ignore
-    async sendTransaction(transactionOpts:{recipientAddress: string, recipientAmount:number, memo?: string}, lcdcUrl?: string): any{
+    async sendTransaction(transactionOpts:{recipientAddress: string, recipientAmount:number, memo?: string}): any{
         // create a simple message that moves coin balances
         const send = new MsgSend(
             this.getAddress(),
             transactionOpts.recipientAddress,
-    { ujmes: transactionOpts.recipientAmount}
+            { ujmes: transactionOpts.recipientAmount}
         );
         const txOpts = {msgs: [send]};
         if(transactionOpts.memo){
             //@ts-ignore
-
             txOpts.memo = transactionOpts.memo;
         }
 
-        const URL = lcdcUrl ?? 'http://51.38.52.37:1317';
-        const lcdc = new LCDClient({
-            chainID: 'jmes-888',
-            // chainID: 'testing',
-            URL,
-            isClassic: true
-        });
-
+        // const URL = lcdcUrl ?? 'http://51.38.52.37:1317';
+        const lcdClient = await this.getLCDClient();
 
         // @ts-ignore
-        return lcdc.wallet(new RawKey(this.getPrivate()))
+        return lcdClient.wallet(new RawKey(this.getPrivate()))
             //@ts-ignore
             .createAndSignTx(txOpts)
             //@ts-ignore
@@ -114,7 +95,7 @@ export class Account {
                 console.log(`TX hash: ${result.txhash}`);
                 return result
             }).catch((e: any)=>{
-                console.log(e);
+                // console.log(e);
                 throw e;
             });
     }

--- a/src/primitives/Wallet/Wallet.ts
+++ b/src/primitives/Wallet/Wallet.ts
@@ -1,16 +1,17 @@
 import {Account} from '../Account'
 import {DerivableKey} from '../DerivableKey'
+import {LCDClient} from "Client/providers/LCDClient/lcd/LCDClient";
 export class Wallet {
     private chainDerivedKey: DerivableKey;
-    public lcdcUrl: string | null;
+    public lcdcInstance: LCDClient | null;
 
-    constructor(chainDerivedKey: DerivableKey, lcdcUrl?: string) {
+    constructor(chainDerivedKey: DerivableKey, lcdcInstance?: LCDClient) {
         this.chainDerivedKey = chainDerivedKey;
-        this.lcdcUrl = lcdcUrl ?? null;
+        this.lcdcInstance = lcdcInstance ?? null;
     }
 
     getAccount(index:number=0){
-        return new Account(this.chainDerivedKey, index, this.lcdcUrl);
+        return new Account(this.chainDerivedKey, index, this.lcdcInstance);
     }
 
     signMessage(message: any){


### PR DESCRIPTION
This PR changes how we manage the LCDClient, instead of having multiple instance, we will pass along the instance created directly from Client to avoid confusion and provide a single way to deal with all. 

We will instead rely on the person to specifically create it's own "LCDC" client, and potentially replacing the instance in Account if he feels he needs it, instead of planning that for him which will be for 99% of the case a unnecessary trouble to deal with. 